### PR TITLE
Remove list windows functionality

### DIFF
--- a/src/handlers/tools.test.ts
+++ b/src/handlers/tools.test.ts
@@ -28,7 +28,6 @@ vi.mock('../tools/keyboard.js', () => ({
 vi.mock('../tools/screen.js', () => ({
   getScreenSize: vi.fn(),
   getActiveWindow: vi.fn(),
-  listAllWindows: vi.fn(),
   focusWindow: vi.fn(),
   resizeWindow: vi.fn(),
   repositionWindow: vi.fn(),

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -24,7 +24,6 @@ import {
 import { 
   getScreenSize, 
   getActiveWindow,
-  listAllWindows,
   focusWindow,
   resizeWindow,
   repositionWindow
@@ -294,14 +293,6 @@ export function setupTools(server: Server): void {
         }
       },
       {
-        name: "list_windows",
-        description: "Get a list of all visible windows with their information",
-        inputSchema: {
-          type: "object",
-          properties: {}
-        }
-      },
-      {
         name: "focus_window",
         description: "Focus a specific window by its title",
         inputSchema: {
@@ -565,9 +556,6 @@ export function setupTools(server: Server): void {
           response = getActiveWindow();
           break;
 
-        case "list_windows":
-          response = await listAllWindows();
-          break;
 
         case "focus_window":
           if (typeof args?.title !== 'string') {

--- a/src/tools/screen.test.ts
+++ b/src/tools/screen.test.ts
@@ -22,7 +22,6 @@ import libnut from '@nut-tree/libnut';
 import { 
   getScreenSize, 
   getActiveWindow, 
-  listAllWindows, 
   focusWindow,
   resizeWindow,
   repositionWindow
@@ -118,90 +117,6 @@ describe('Screen Functions', () => {
     });
   });
 
-  describe('listAllWindows', () => {
-    it('should return list of windows on success', async () => {
-      // Setup
-      (libnut.getWindows as any).mockReturnValue([1, 2, 3]);
-      (libnut.getWindowTitle as any).mockImplementation((handle: number) => `Window ${handle}`);
-      (libnut.getWindowRect as any).mockImplementation((handle: number) => ({ 
-        x: handle * 10, 
-        y: handle * 20, 
-        width: 800, 
-        height: 600 
-      }));
-
-      // Execute
-      const result = await listAllWindows();
-
-      // Verify
-      expect(libnut.getWindows).toHaveBeenCalledTimes(1);
-      expect(libnut.getWindowTitle).toHaveBeenCalledTimes(3);
-      expect(libnut.getWindowRect).toHaveBeenCalledTimes(3);
-      expect(result).toEqual({
-        success: true,
-        message: "Window list retrieved successfully",
-        data: [
-          {
-            title: 'Window 1',
-            position: { x: 10, y: 20 },
-            size: { width: 800, height: 600 }
-          },
-          {
-            title: 'Window 2',
-            position: { x: 20, y: 40 },
-            size: { width: 800, height: 600 }
-          },
-          {
-            title: 'Window 3',
-            position: { x: 30, y: 60 },
-            size: { width: 800, height: 600 }
-          }
-        ]
-      });
-    });
-
-    it('should skip windows that cannot be accessed', async () => {
-      // Setup
-      (libnut.getWindows as any).mockReturnValue([1, 2, 3]);
-      (libnut.getWindowTitle as any).mockImplementation((handle: number) => {
-        if (handle === 2) throw new Error('Cannot access window');
-        return `Window ${handle}`;
-      });
-      (libnut.getWindowRect as any).mockImplementation((handle: number) => ({ 
-        x: handle * 10, 
-        y: handle * 20, 
-        width: 800, 
-        height: 600 
-      }));
-
-      // Execute
-      const result = await listAllWindows();
-
-      // Verify
-      expect(result.success).toBe(true);
-      if (result.data && Array.isArray(result.data)) {
-        expect(result.data).toHaveLength(2);
-        expect(result.data[0].title).toBe('Window 1');
-        expect(result.data[1].title).toBe('Window 3');
-      }
-    });
-
-    it('should return error response when window list fails', async () => {
-      // Setup
-      (libnut.getWindows as any).mockImplementation(() => {
-        throw new Error('Cannot list windows');
-      });
-
-      // Execute
-      const result = await listAllWindows();
-
-      // Verify
-      expect(result).toEqual({
-        success: false,
-        message: "Failed to list windows: Cannot list windows"
-      });
-    });
-  });
 
   describe('focusWindow', () => {
     it('should focus window with matching title', () => {

--- a/src/tools/screen.ts
+++ b/src/tools/screen.ts
@@ -47,48 +47,6 @@ export function getActiveWindow(): WindowsControlResponse {
   }
 }
 
-export async function listAllWindows(): Promise<WindowsControlResponse> {
-  try {
-    const handles = libnut.getWindows();
-    
-    const windowsWithNull = await Promise.all(
-      handles.map((handle) => {
-        try {
-          const title = libnut.getWindowTitle(handle);
-          const rect = libnut.getWindowRect(handle);
-          
-          // Skip windows at (0,0) or with zero dimensions
-          if ((rect.x === 0 && rect.y === 0) || (rect.width === 0 || rect.height === 0)) {
-            return null;
-          }
-          
-          return {
-            title: title,
-            position: { x: rect.x, y: rect.y },
-            size: { width: rect.width, height: rect.height }
-          } as WindowInfo;
-        } catch {
-          return null;
-        }
-      })
-    );
-
-    const windows = windowsWithNull.filter((window: WindowInfo | null): window is WindowInfo => 
-      window !== null && window.title.trim() !== ''
-    );
-
-    return {
-      success: true,
-      message: "Window list retrieved successfully",
-      data: windows
-    };
-  } catch (error) {
-    return {
-      success: false,
-      message: `Failed to list windows: ${error instanceof Error ? error.message : String(error)}`
-    };
-  }
-}
 
 export function focusWindow(title: string): WindowsControlResponse {
   try {


### PR DESCRIPTION
## Summary
- Removes the list windows tool which was producing excessive output as mentioned in issue #27
- Removes all references to listAllWindows from screen.ts, screen.test.ts, tools.ts, and tools.test.ts

## Test plan
- Ran tests to ensure all functionality still works
- Verified that the removed tool doesn't appear in API

🤖 Generated with [Claude Code](https://claude.ai/code)