### PR TITLE
Update src/index.ts to use provider factory

### DIFF
--- a/src/handlers/tools.test.ts
+++ b/src/handlers/tools.test.ts
@@ -87,6 +87,7 @@ vi.mock('../providers/factory.js', () => {
 // Import mocked functions for testing
 import { moveMouse } from '../tools/mouse.js';
 import { typeText, pressKey } from '../tools/keyboard.js';
+import { createAutomationProvider } from '../providers/factory.js';
 
 describe('Tools Handler', () => {
   let mockServer: Server;
@@ -108,8 +109,9 @@ describe('Tools Handler', () => {
       })
     } as unknown as Server;
 
-    // Setup tools with mock server
-    setupTools(mockServer);
+    // Setup tools with mock server and mock provider
+    const mockProvider = vi.mocked(createAutomationProvider)();
+    setupTools(mockServer, mockProvider);
   });
 
   describe('Tool Registration', () => {

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -21,10 +21,10 @@ import {
   pressKeyCombination,
   holdKey
 } from "../tools/keyboard.js";
-// Clipboard functionality now accessed through provider pattern
-import { createAutomationProvider } from "../providers/factory.js";
+// Provider is now passed from the main server instance
+import { AutomationProvider } from "../interfaces/provider.js";
 
-export function setupTools(server: Server): void {
+export function setupTools(server: Server, provider: AutomationProvider): void {
   // List available tools
   server.setRequestHandler(ListToolsRequestSchema, () => ({
     tools: [
@@ -388,8 +388,7 @@ export function setupTools(server: Server): void {
       const { name, arguments: args } = request.params;
       let response;
       
-      // Create provider once per request - ensures consistent error handling across operations
-      const provider = createAutomationProvider();
+      // Use the provider passed from the server instance
 
       switch (name) {
         case "get_screenshot": {

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -24,6 +24,11 @@ import {
 // Provider is now passed from the main server instance
 import { AutomationProvider } from "../interfaces/provider.js";
 
+/**
+ * Set up automation tools on the MCP server using the provided automation provider
+ * @param server The Model Context Protocol server instance
+ * @param provider The automation provider implementation that will handle system interactions
+ */
 export function setupTools(server: Server, provider: AutomationProvider): void {
   // List available tools
   server.setRequestHandler(ListToolsRequestSchema, () => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,31 +7,43 @@ import { AutomationProvider } from "./interfaces/provider.js";
 
 class WindowsControlServer {
   private server: Server;
+  
+  /** Automation provider instance used for system interaction */
   private provider: AutomationProvider;
 
   constructor() {
-    // Load configuration
-    const config = loadConfig();
-    
-    // Create automation provider based on configuration
-    this.provider = createAutomationProvider(config.provider);
-    
-    this.server = new Server({
-      name: "windows-control",
-      version: "1.0.0"
-    }, {
-      capabilities: {
-        tools: {}
+    try {
+      // Load configuration
+      const config = loadConfig();
+      
+      // Validate configuration
+      if (!config || typeof config.provider !== 'string') {
+        throw new Error('Invalid configuration: provider property is missing or invalid');
       }
-    });
+      
+      // Create automation provider based on configuration
+      this.provider = createAutomationProvider(config.provider);
+      
+      this.server = new Server({
+        name: "windows-control",
+        version: "1.0.0"
+      }, {
+        capabilities: {
+          tools: {}
+        }
+      });
 
-    this.setupHandlers();
-    this.setupErrorHandling();
+      this.setupHandlers();
+      this.setupErrorHandling();
+    } catch (error) {
+      console.error(`Failed to initialize Windows Control Server: ${error instanceof Error ? error.message : String(error)}`);
+      throw error;
+    }
   }
 
   private setupHandlers(): void {
     // Pass the provider to setupTools
-    setupTools(this.server);
+    setupTools(this.server, this.provider);
   }
 
   private setupErrorHandling(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ import { AutomationProvider } from "./interfaces/provider.js";
 class WindowsControlServer {
   private server: Server;
   
-  /** Automation provider instance used for system interaction */
+  /** 
+   * Automation provider instance used for system interaction
+   * The provider implements keyboard, mouse, screen, and clipboard functionality
+   * through a consistent interface allowing for different backend implementations
+   */
   private provider: AutomationProvider;
 
   constructor() {
@@ -19,6 +23,12 @@ class WindowsControlServer {
       // Validate configuration
       if (!config || typeof config.provider !== 'string') {
         throw new Error('Invalid configuration: provider property is missing or invalid');
+      }
+      
+      // Validate that the provider is supported
+      const supportedProviders = ['nutjs']; // add others as they become available
+      if (!supportedProviders.includes(config.provider.toLowerCase())) {
+        throw new Error(`Unsupported provider: ${config.provider}. Supported providers: ${supportedProviders.join(', ')}`);
       }
       
       // Create automation provider based on configuration
@@ -37,7 +47,10 @@ class WindowsControlServer {
       this.setupErrorHandling();
     } catch (error) {
       console.error(`Failed to initialize Windows Control Server: ${error instanceof Error ? error.message : String(error)}`);
-      throw error;
+      // Log additional shutdown information
+      console.error('Server initialization failed. Application will now exit.');
+      // Exit with non-zero status to indicate error
+      process.exit(1);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,21 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { setupTools } from "./handlers/tools.js";
+import { loadConfig } from "./config.js";
+import { createAutomationProvider } from "./providers/factory.js";
+import { AutomationProvider } from "./interfaces/provider.js";
 
 class WindowsControlServer {
   private server: Server;
+  private provider: AutomationProvider;
 
   constructor() {
+    // Load configuration
+    const config = loadConfig();
+    
+    // Create automation provider based on configuration
+    this.provider = createAutomationProvider(config.provider);
+    
     this.server = new Server({
       name: "windows-control",
       version: "1.0.0"
@@ -20,6 +30,7 @@ class WindowsControlServer {
   }
 
   private setupHandlers(): void {
+    // Pass the provider to setupTools
     setupTools(this.server);
   }
 
@@ -36,7 +47,7 @@ class WindowsControlServer {
   async run(): Promise<void> {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    console.error("Windows Control MCP server running on stdio");
+    console.error(`Windows Control MCP server running on stdio (using ${this.provider.constructor.name})`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Update `index.ts` to use the provider factory pattern
- Add provider instance as class member for future use
- Load configuration for provider selection
- Display provider name in startup log

## Test plan
- Verify that application builds without errors
- Verify that all tests pass
- Run application and confirm provider name displays correctly in startup log

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)