### PR TITLE
Modify tool handlers to use injected providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ By using this software, you acknowledge and accept that:
   - Reposition windows
 
 - **Mouse Control**
-  - Mouse movement with configurable speed
+  - Mouse movement
   - Click operations
   - Scroll functionality
   - Drag operations

--- a/TASKS.md
+++ b/TASKS.md
@@ -62,7 +62,6 @@
 - [x] Basic mouse movement and clicking
 - [x] Mouse scroll (up/down)
 - [x] Mouse drag operations
-- [x] Set mouse movement speed
 - [x] Cursor position tracking
 
 ### Keyboard Control

--- a/src/handlers/tools.test.ts
+++ b/src/handlers/tools.test.ts
@@ -165,6 +165,58 @@ describe('Tools Handler', () => {
       });
     });
 
+    it('should execute click_mouse tool with default button', async () => {
+      const mockProvider = vi.mocked(createAutomationProvider)();
+      vi.mocked(mockProvider.mouse.clickMouse).mockReturnValueOnce({ success: true, message: 'Mouse clicked' });
+
+      const result = await callToolHandler({
+        params: {
+          name: 'click_mouse',
+          arguments: {}
+        }
+      });
+
+      expect(mockProvider.mouse.clickMouse).toHaveBeenCalledWith('left');
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        success: true,
+        message: 'Mouse clicked'
+      });
+    });
+
+    it('should execute click_mouse tool with specified button', async () => {
+      const mockProvider = vi.mocked(createAutomationProvider)();
+      vi.mocked(mockProvider.mouse.clickMouse).mockReturnValueOnce({ success: true, message: 'Right mouse clicked' });
+
+      const result = await callToolHandler({
+        params: {
+          name: 'click_mouse',
+          arguments: { button: 'right' }
+        }
+      });
+
+      expect(mockProvider.mouse.clickMouse).toHaveBeenCalledWith('right');
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        success: true,
+        message: 'Right mouse clicked'
+      });
+    });
+
+    it('should execute press_key tool with valid arguments', async () => {
+      const mockProvider = vi.mocked(createAutomationProvider)();
+      
+      const result = await callToolHandler({
+        params: {
+          name: 'press_key',
+          arguments: { key: 'enter' }
+        }
+      });
+
+      expect(mockProvider.keyboard.pressKey).toHaveBeenCalledWith('enter');
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        success: true,
+        message: 'Key pressed'
+      });
+    });
   });
 
   describe('Error Handling', () => {

--- a/src/handlers/tools.test.ts
+++ b/src/handlers/tools.test.ts
@@ -11,7 +11,6 @@ vi.mock('../tools/mouse.js', () => ({
   getCursorPosition: vi.fn(),
   scrollMouse: vi.fn(),
   dragMouse: vi.fn(),
-  setMouseSpeed: vi.fn(),
   clickAt: vi.fn()
 }));
 
@@ -84,9 +83,7 @@ vi.mock('../providers/factory.js', () => {
   };
 });
 
-// Import mocked functions for testing
-import { moveMouse } from '../tools/mouse.js';
-import { typeText, pressKey } from '../tools/keyboard.js';
+// Import for mocking
 import { createAutomationProvider } from '../providers/factory.js';
 
 describe('Tools Handler', () => {
@@ -134,6 +131,7 @@ describe('Tools Handler', () => {
   describe('Tool Execution', () => {
     it('should execute move_mouse tool with valid arguments', async () => {
       // Mock is already setup in the mock declaration with default success response
+      const mockProvider = vi.mocked(createAutomationProvider)();
 
       const result = await callToolHandler({
         params: {
@@ -142,7 +140,7 @@ describe('Tools Handler', () => {
         }
       });
 
-      expect(moveMouse).toHaveBeenCalledWith({ x: 100, y: 200 });
+      expect(mockProvider.mouse.moveMouse).toHaveBeenCalledWith({ x: 100, y: 200 });
       expect(JSON.parse(result.content[0].text)).toEqual({
         success: true,
         message: 'Mouse moved'
@@ -151,6 +149,7 @@ describe('Tools Handler', () => {
 
     it('should execute type_text tool with valid arguments', async () => {
       // Mock is already setup in the mock declaration with default success response
+      const mockProvider = vi.mocked(createAutomationProvider)();
 
       const result = await callToolHandler({
         params: {
@@ -159,7 +158,7 @@ describe('Tools Handler', () => {
         }
       });
 
-      expect(typeText).toHaveBeenCalledWith({ text: 'Hello World' });
+      expect(mockProvider.keyboard.typeText).toHaveBeenCalledWith({ text: 'Hello World' });
       expect(JSON.parse(result.content[0].text)).toEqual({
         success: true,
         message: 'Text typed'
@@ -194,7 +193,8 @@ describe('Tools Handler', () => {
     });
 
     it('should handle tool execution errors', async () => {
-      vi.mocked(pressKey).mockImplementationOnce(() => {
+      const mockProvider = vi.mocked(createAutomationProvider)();
+      vi.mocked(mockProvider.keyboard.pressKey).mockImplementationOnce(() => {
         throw new Error('Key press failed');
       });
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -10,7 +10,27 @@ import { MousePosition, KeyboardInput, KeyCombination, ClipboardInput, KeyHoldOp
 import { AutomationProvider } from "../interfaces/provider.js";
 
 /**
- * Set up automation tools on the MCP server using the provided automation provider
+ * Validates the mouse button parameter and returns a valid button value
+ * @param button The button parameter to validate
+ * @returns A validated mouse button value: 'left', 'right', or 'middle'
+ */
+function validateButton(button?: unknown): 'left' | 'right' | 'middle' {
+  return (typeof button === 'string' && 
+    ['left', 'right', 'middle'].includes(button)) ? 
+    button as 'left' | 'right' | 'middle' : 'left';
+}
+
+/**
+ * Set up automation tools on the MCP server using the provided automation provider.
+ * This function implements the provider pattern for all tool handlers, allowing
+ * for dependency injection of automation implementations.
+ * 
+ * The provider pattern offers several benefits:
+ * - Testability: Makes unit testing easier by allowing mock providers
+ * - Flexibility: Allows changing provider implementations without changing tool handlers
+ * - Consistency: Ensures all automation is handled through a single provider interface
+ * - Maintainability: Reduces direct dependencies on specific implementation details
+ * 
  * @param server The Model Context Protocol server instance
  * @param provider The automation provider implementation that will handle system interactions
  */
@@ -443,9 +463,7 @@ export function setupTools(server: Server, provider: AutomationProvider): void {
           response = provider.mouse.clickAt(
             args.x,
             args.y,
-            (typeof args?.button === 'string' && 
-              (args.button === 'left' || args.button === 'right' || args.button === 'middle')) ? 
-              args.button : 'left'
+            validateButton(args?.button)
           );
           break;
 
@@ -458,9 +476,7 @@ export function setupTools(server: Server, provider: AutomationProvider): void {
 
         case "click_mouse":
           response = provider.mouse.clickMouse(
-            (typeof args?.button === 'string' && 
-              (args.button === 'left' || args.button === 'right' || args.button === 'middle')) ? 
-              args.button : 'left'
+            validateButton(args?.button)
           );
           break;
 
@@ -474,9 +490,7 @@ export function setupTools(server: Server, provider: AutomationProvider): void {
           response = provider.mouse.dragMouse(
             { x: args.fromX, y: args.fromY },
             { x: args.toX, y: args.toY },
-            (typeof args?.button === 'string' && 
-              (args.button === 'left' || args.button === 'right' || args.button === 'middle')) ? 
-              args.button : 'left'
+            validateButton(args?.button)
           );
           break;
 
@@ -629,18 +643,33 @@ export function setupTools(server: Server, provider: AutomationProvider): void {
   });
 }
 
+/**
+ * Type guard to validate if an object matches the MousePosition interface
+ * @param args The object to validate
+ * @returns True if the object is a valid MousePosition
+ */
 function isMousePosition(args: unknown): args is MousePosition {
   if (typeof args !== 'object' || args === null) return false;
   const pos = args as Record<string, unknown>;
   return typeof pos.x === 'number' && typeof pos.y === 'number';
 }
 
+/**
+ * Type guard to validate if an object matches the KeyboardInput interface
+ * @param args The object to validate
+ * @returns True if the object is a valid KeyboardInput
+ */
 function isKeyboardInput(args: unknown): args is KeyboardInput {
   if (typeof args !== 'object' || args === null) return false;
   const input = args as Record<string, unknown>;
   return typeof input.text === 'string';
 }
 
+/**
+ * Type guard to validate if an object matches the KeyCombination interface
+ * @param args The object to validate
+ * @returns True if the object is a valid KeyCombination
+ */
 function isKeyCombination(args: unknown): args is KeyCombination {
   if (typeof args !== 'object' || args === null) return false;
   const combo = args as Record<string, unknown>;
@@ -648,6 +677,11 @@ function isKeyCombination(args: unknown): args is KeyCombination {
   return combo.keys.every(key => typeof key === 'string');
 }
 
+/**
+ * Type guard to validate if an object matches the KeyHoldOperation interface
+ * @param args The object to validate
+ * @returns True if the object is a valid KeyHoldOperation
+ */
 function isKeyHoldOperation(args: unknown): args is KeyHoldOperation {
   if (typeof args !== 'object' || args === null) return false;
   const op = args as Record<string, unknown>;
@@ -658,6 +692,11 @@ function isKeyHoldOperation(args: unknown): args is KeyHoldOperation {
   );
 }
 
+/**
+ * Type guard to validate if an object matches the ClipboardInput interface
+ * @param args The object to validate
+ * @returns True if the object is a valid ClipboardInput
+ */
 function isClipboardInput(args: unknown): args is ClipboardInput {
   if (typeof args !== 'object' || args === null) return false;
   const input = args as Record<string, unknown>;

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -160,21 +160,3 @@ export function clickAt(x: number, y: number, button: keyof ButtonMap = 'left'):
   }
 }
 
-export function setMouseSpeed(speed: number): WindowsControlResponse {
-  try {
-    // Speed is in milliseconds. Lower values = faster movement
-    // Clamp between 1 and 100 for safety
-    const clampedSpeed = Math.max(1, Math.min(100, speed));
-    libnut.setMouseDelay(clampedSpeed);
-    
-    return {
-      success: true,
-      message: `Mouse speed set to ${clampedSpeed}ms delay`
-    };
-  } catch (error) {
-    return {
-      success: false,
-      message: `Failed to set mouse speed: ${error instanceof Error ? error.message : String(error)}`
-    };
-  }
-}


### PR DESCRIPTION
## Summary
* Update tool handlers to consistently use the injected provider
* Remove mouse speed functionality as it's no longer needed
* Update tests to work with provider-based implementations
* Update documentation to reflect changes

## Test plan
* Verify all unit tests pass
* Manually test the functionality to ensure it works the same as before
* Confirm build, lint, and test scripts run successfully

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)