### PR TITLE
feat: enable Windows key and Win+R combination

### DIFF
--- a/src/tools/validation.zod.ts
+++ b/src/tools/validation.zod.ts
@@ -56,6 +56,7 @@ export const VALID_KEYS = [
   'shift',
   'right_shift',
   'command',
+  'windows',
   'enter',
   'return',
   'backspace',
@@ -172,10 +173,7 @@ function isDangerousKeyCombination(keys: string[]): string | null {
       return 'This combination can trigger system functions';
     }
 
-    // Windows key combinations
-    if (normalizedKeys.includes('command') && normalizedKeys.includes('r')) {
-      return 'This combination can open the Run dialog';
-    }
+    // Allow Windows+R (Run dialog)
 
     if (
       (normalizedKeys.includes('control') || normalizedKeys.includes('command')) &&


### PR DESCRIPTION
## Summary
- Added 'windows' as an alias for the Windows key
- Removed restriction on Win+R key combination
- Enables launching applications via Windows key shortcuts

## Test plan
- [x] Verified 'windows' key can be used individually
- [x] Verified 'windows+r' combination can be used
- [x] All unit tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)