### PR TITLE
feat: upgrade to MCP SDK 1.10.2 for HTTP streaming support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "mcp-control",
-  "version": "0.1.17",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-control",
-      "version": "0.1.17",
+      "version": "0.1.21",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.1",
+        "@modelcontextprotocol/sdk": "^1.10.2",
         "clipboardy": "^4.0.0",
         "express": "^5.1.0",
         "jimp": "^1.6.0",
@@ -1563,10 +1563,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.1.tgz",
-      "integrity": "sha512-xNYdFdkJqEfIaTVP1gPKoEvluACHZsHZegIoICX8DM1o6Qf3G5u2BQJHmgd0n4YgRPqqK/u1ujQvrgAxxSJT9w==",
-      "license": "MIT",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
+      "integrity": "sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==",
       "dependencies": {
         "content-type": "^1.0.5",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-control",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Windows control server for the Model Context Protocol",
   "license": "MIT",
   "type": "module",
@@ -21,7 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.1",
+    "@modelcontextprotocol/sdk": "^1.10.2",
     "clipboardy": "^4.0.0",
     "express": "^5.1.0",
     "jimp": "^1.6.0",


### PR DESCRIPTION
## Summary
- Upgrade @modelcontextprotocol/sdk from 1.10.1 to 1.10.2 to support new HTTP streaming functionality
- Bump package version to 0.1.22

## Test plan
- Confirmed all tests pass
- Verified build completes successfully
- Checked that linting and formatting are valid

🤖 Generated with [Claude Code](https://claude.ai/code)