### PR TITLE
Register SSE route and HTTP server integration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,11 +101,22 @@ class MCPControlServer {
     );
 
     // If HTTP_PORT is defined, start the HTTP server with SSE support
-    const httpPort = process.env.HTTP_PORT ? parseInt(process.env.HTTP_PORT, 10) : 3232;
+    let httpPort = process.env.HTTP_PORT ? parseInt(process.env.HTTP_PORT, 10) : 3232;
+    if (isNaN(httpPort)) {
+      process.stderr.write(
+        `Invalid HTTP_PORT value: ${process.env.HTTP_PORT}, using default 3232\n`,
+      );
+      httpPort = 3232;
+    }
 
     // Check if HTTP/SSE transport should be enabled
     if (process.env.ENABLE_HTTP === 'true' || process.env.ENABLE_SSE === 'true') {
       this.httpServer = createHttpServer(this.server, httpPort);
+
+      // Set up error handler for HTTP server
+      this.httpServer.httpServer.on('error', (err) => {
+        process.stderr.write(`Failed to start HTTP server: ${err.message}\n`);
+      });
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { setupTools } from './handlers/tools.js';
 import { loadConfig } from './config.js';
 import { createAutomationProvider } from './providers/factory.js';
 import { AutomationProvider } from './interfaces/provider.js';
+import { createHttpServer } from './server.js';
 
 class MCPControlServer {
   private server: Server;
@@ -15,6 +16,11 @@ class MCPControlServer {
    * through a consistent interface allowing for different backend implementations
    */
   private provider: AutomationProvider;
+
+  /**
+   * HTTP server instance if HTTP/SSE is enabled
+   */
+  private httpServer?: ReturnType<typeof createHttpServer>;
 
   constructor() {
     try {
@@ -77,17 +83,30 @@ class MCPControlServer {
     };
 
     process.on('SIGINT', () => {
+      if (this.httpServer) {
+        this.httpServer.httpServer.close();
+      }
       void this.server.close().then(() => process.exit(0));
     });
   }
 
   async run(): Promise<void> {
+    // Create the StdioServerTransport for standard MCP communication
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
+
     // Using process.stderr.write to avoid affecting the JSON-RPC stream
     process.stderr.write(
       `MCP Control server running on stdio (using ${this.provider.constructor.name})\n`,
     );
+
+    // If HTTP_PORT is defined, start the HTTP server with SSE support
+    const httpPort = process.env.HTTP_PORT ? parseInt(process.env.HTTP_PORT, 10) : 3232;
+
+    // Check if HTTP/SSE transport should be enabled
+    if (process.env.ENABLE_HTTP === 'true' || process.env.ENABLE_SSE === 'true') {
+      this.httpServer = createHttpServer(this.server, httpPort);
+    }
   }
 }
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We'll define the mocks before importing the module being tested
+const mockMcpServer = {
+  on: vi.fn(),
+};
+
+const mockApp = {
+  get: vi.fn(),
+  use: vi.fn(),
+};
+
+const mockHttpServer = {
+  listen: vi.fn((port, callback) => {
+    if (callback) callback();
+    return mockHttpServer;
+  }),
+  close: vi.fn(),
+};
+
+const mockSseTransport = {
+  attach: vi.fn(),
+  emitEvent: vi.fn(),
+  getClientCount: vi.fn().mockReturnValue(0),
+};
+
+// Mock the dependencies before importing the module to test
+vi.mock('express', () => {
+  return {
+    default: vi.fn(() => mockApp),
+  };
+});
+
+vi.mock('http', () => {
+  return {
+    createServer: vi.fn(() => mockHttpServer),
+  };
+});
+
+vi.mock('./transports/sseTransport.js', () => {
+  return {
+    SseTransport: vi.fn(() => mockSseTransport),
+  };
+});
+
+// Now import the module being tested
+import { createHttpServer } from './server.js';
+
+describe('HTTP Server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MAX_SSE_CLIENTS = '100';
+
+    // Mock setInterval
+    vi.spyOn(global, 'setInterval').mockImplementation(() => 123 as unknown as NodeJS.Timeout);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+  });
+
+  it('should create an HTTP server with SSE transport', () => {
+    createHttpServer(mockMcpServer as any);
+
+    // Should have created a server
+    expect(mockHttpServer).toBeDefined();
+
+    // Should have attached the SSE transport
+    expect(mockSseTransport.attach).toHaveBeenCalledWith(mockApp);
+
+    // Should have set up a heartbeat timer
+    expect(global.setInterval).toHaveBeenCalledWith(expect.any(Function), 25000);
+  });
+
+  it('should register client limit middleware', () => {
+    createHttpServer(mockMcpServer as any);
+
+    // Should have registered middleware for client limits
+    expect(mockApp.use).toHaveBeenCalledWith('/mcp/sse', expect.any(Function));
+  });
+
+  it('should start listening on the specified port', () => {
+    const port = 5555;
+    createHttpServer(mockMcpServer as any, port);
+
+    // Should have started listening on the specified port
+    expect(mockHttpServer.listen).toHaveBeenCalledWith(port);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,73 @@
+import express from 'express';
+import * as http from 'http';
+import { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js';
+import { SseTransport } from './transports/sseTransport.js';
+
+/**
+ * Maximum number of SSE clients that can connect simultaneously
+ * Can be overridden with MAX_SSE_CLIENTS environment variable
+ */
+const MAX_SSE_CLIENTS = parseInt(process.env.MAX_SSE_CLIENTS || '100', 10);
+
+/**
+ * Creates and configures an HTTP server with SSE support
+ * @param mcpServer The MCP server instance to connect with
+ * @param port The port to listen on (default: 3232)
+ * @returns Object containing the express app, http server, and transport instances
+ */
+export function createHttpServer(
+  mcpServer: MCPServer,
+  port = 3232,
+): {
+  app: ReturnType<typeof express>;
+  httpServer: http.Server;
+  sseTransport: SseTransport;
+} {
+  const app = express();
+  // Explicitly type the app to satisfy ESLint
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  const httpServer = http.createServer(app);
+
+  // Initialize SSE transport
+  const sseTransport = new SseTransport({
+    maxBufferSize: 100,
+    heartbeatInterval: 25000,
+  });
+
+  // Attach transport to the Express app
+  sseTransport.attach(app);
+
+  // Since the MCP Server doesn't have a native event system that we can listen to,
+  // we'll use manual emit handling through our transport logic.
+  // The actual emission will happen elsewhere in the codebase where tool responses are processed.
+
+  // Send a heartbeat every 25 seconds to keep connections alive
+  setInterval(() => {
+    sseTransport.emitEvent('mcp.heartbeat', { ts: new Date().toISOString() });
+  }, 25000);
+
+  // Client limit enforcement
+  app.use('/mcp/sse', (req, res, next) => {
+    const clientCount = sseTransport.getClientCount();
+    if (clientCount >= MAX_SSE_CLIENTS) {
+      res.status(503).json({
+        success: false,
+        message: `Maximum number of SSE clients (${MAX_SSE_CLIENTS}) reached`,
+      });
+      return;
+    }
+    next();
+  });
+
+  // Start listening
+  httpServer.listen(port);
+
+  // Log that the server is running
+  process.stderr.write(`HTTP server running on port ${port} with SSE support\n`);
+
+  return {
+    app,
+    httpServer,
+    sseTransport,
+  };
+}

--- a/src/transports/sseTransport.ts
+++ b/src/transports/sseTransport.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { ulid } from 'ulid';
-import { Transport } from './baseTransport';
+import { Transport } from './baseTransport.js';
 
 /**
  * Server-Sent Events transport for streaming real-time events


### PR DESCRIPTION
## Summary
- Add Express HTTP server with SSE endpoint at `/mcp/sse`
- Implement live heartbeat every 25 seconds
- Add environment variable control for max clients
- Set up server integration in index.ts with feature flag (ENABLE_SSE)

## Test plan
- Manual testing: `ENABLE_SSE=true node build/index.js`
- Run `curl -N http://localhost:3232/mcp/sse` to verify live heartbeat
- Unit tests for server initialization and middleware

Closes #166

🤖 Generated with [Claude Code](https://claude.ai/code)