### PR TITLE
fix: standardize default port to 3232 across codebase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { setupTools } from './handlers/tools.js';
 import { loadConfig } from './config.js';
 import { createAutomationProvider } from './providers/factory.js';
 import { AutomationProvider } from './interfaces/provider.js';
-import { createHttpServer } from './server.js';
+import { createHttpServer, DEFAULT_PORT } from './server.js';
 
 class MCPControlServer {
   private useSse: boolean;
@@ -106,7 +106,7 @@ class MCPControlServer {
 
     // Start HTTP server with SSE support if requested
     if (this.useSse) {
-      const port = this.port ?? 3000;
+      const port = this.port ?? DEFAULT_PORT;
       this.httpServer = createHttpServer(this.server, port);
 
       // Set up error handler for HTTP server

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,11 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { networkInterfaces } from 'os';
 
 /**
+ * Default port for the SSE server
+ */
+export const DEFAULT_PORT = 3232;
+
+/**
  * Maximum number of SSE clients that can connect simultaneously
  * Can be overridden with MAX_SSE_CLIENTS environment variable
  */
@@ -13,12 +18,12 @@ const MAX_SSE_CLIENTS = parseInt(process.env.MAX_SSE_CLIENTS || '100', 10);
 /**
  * Creates and configures an HTTP server with SSE support
  * @param mcpServer The MCP server instance to connect with
- * @param port The port to listen on (default: 3232)
+ * @param port The port to listen on (default: DEFAULT_PORT)
  * @returns Object containing the express app, http server
  */
 export function createHttpServer(
   mcpServer: MCPServer,
-  port = 3232,
+  port = DEFAULT_PORT,
 ): {
   app: ReturnType<typeof express>;
   httpServer: http.Server;


### PR DESCRIPTION
## Summary
- Added DEFAULT_PORT constant in server.ts set to 3232
- Updated index.ts to use the exported constant instead of hardcoding 3000
- Ensures consistent port usage throughout the application

## Test plan
- [x] Build succeeds without errors
- [x] Server starts with default port 3232 when using SSE mode
- [x] Explicit port override still works when provided via CLI

🤖 Generated with [Claude Code](https://claude.ai/code)