### PR TITLE
Make AutoHotkey the default provider and improve Windows documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To launch MCPControl locally with SSE transport:
 
 First, start the MCPControl server on your VM or local machine:
 
-```bash
+```powershell
 mcp-control --sse
 ```
 
@@ -238,30 +238,30 @@ By using this software, you acknowledge and accept that:
 
 MCPControl supports multiple automation providers for different use cases:
 
-- **keysender** (default) - Native Windows automation with high reliability
+- **autohotkey** (default) - AutoHotkey v2 scripting for advanced automation needs
+- **keysender** - Native Windows automation with high reliability (optional)
 - **powershell** - Windows PowerShell-based automation for simpler operations
-- **autohotkey** - AutoHotkey v2 scripting for advanced automation needs
 
 ### Provider Configuration
 
 You can configure the automation provider using environment variables:
 
-```bash
+```powershell
 # Use a specific provider for all operations
-export AUTOMATION_PROVIDER=autohotkey
+$env:AUTOMATION_PROVIDER = "autohotkey"
 
 # Configure AutoHotkey executable path (if not in PATH)
-export AUTOHOTKEY_PATH="C:\Program Files\AutoHotkey\v2\AutoHotkey.exe"
+$env:AUTOHOTKEY_PATH = "C:\Program Files\AutoHotkey\v2\AutoHotkey.exe"
 ```
 
 Or use modular configuration for specific operations:
 
-```bash
+```powershell
 # Mix and match providers for different operations
-export AUTOMATION_KEYBOARD_PROVIDER=autohotkey
-export AUTOMATION_MOUSE_PROVIDER=keysender
-export AUTOMATION_SCREEN_PROVIDER=keysender  
-export AUTOMATION_CLIPBOARD_PROVIDER=powershell
+$env:AUTOMATION_KEYBOARD_PROVIDER = "autohotkey"
+$env:AUTOMATION_MOUSE_PROVIDER = "autohotkey"
+$env:AUTOMATION_SCREEN_PROVIDER = "autohotkey"  
+$env:AUTOMATION_CLIPBOARD_PROVIDER = "powershell"
 ```
 
 See provider-specific documentation:
@@ -275,14 +275,14 @@ If you're interested in contributing or building from source, please see [CONTRI
 
 To build this project for development, you'll need:
 
-1. Windows operating system (required for the keysender dependency)
+1. Windows operating system
 2. Node.js 18 or later (install using the official Windows installer which includes build tools)
 3. npm package manager
-4. Native build tools:
+4. Native build tools (optional, only needed if using the keysender provider):
    - node-gyp: `npm install -g node-gyp`
    - cmake-js: `npm install -g cmake-js`
 
-The keysender dependency relies on Windows-specific native modules that require these build tools.
+The keysender provider is optional and relies on Windows-specific native modules that require these build tools. If you don't need keysender, you can skip installing the build tools.
 
 ## 📋 Project Structure
 

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.2",
     "clipboardy": "^4.0.0",
-    "keysender": "^2.3.0",
     "sharp": "^0.34.1",
     "ulid": "^3.0.0",
     "uuid": "^11.1.0",
     "zod": "^3.24.4"
+  },
+  "optionalDependencies": {
+    "keysender": "^2.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,8 @@
 export interface AutomationConfig {
   /**
    * Legacy: The provider to use for all automation
-   * Currently supported: 'keysender'
+   * Currently supported: 'keysender', 'autohotkey'
+   * Default: 'autohotkey'
    */
   provider?: string;
 
@@ -43,6 +44,6 @@ export function loadConfig(): AutomationConfig {
 
   // Fall back to legacy configuration
   return {
-    provider: process.env.AUTOMATION_PROVIDER || 'keysender',
+    provider: process.env.AUTOMATION_PROVIDER || 'autohotkey',
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ class MCPControlServer {
       }
 
       // Validate that the provider is supported
-      const supportedProviders = ['keysender']; // add others as they become available
+      const supportedProviders = ['keysender', 'autohotkey']; // add others as they become available
       if (!supportedProviders.includes(config.provider.toLowerCase())) {
         throw new Error(
           `Unsupported provider: ${config.provider}. Supported providers: ${supportedProviders.join(', ')}`,

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -72,7 +72,7 @@ export function createAutomationProvider(config?: AutomationConfig): AutomationP
 
   if (!config || !config.providers) {
     // Legacy behavior: use monolithic provider
-    const type = config?.provider || 'keysender';
+    const type = config?.provider || 'autohotkey';
     const providerType = type.toLowerCase();
 
     // Return cached instance if available
@@ -106,19 +106,19 @@ export function createAutomationProvider(config?: AutomationConfig): AutomationP
   // Get individual components from the registry
   const keyboardProvider = config.providers.keyboard
     ? registry.getKeyboard(config.providers.keyboard)
-    : new KeysenderProvider().keyboard;
+    : new AutoHotkeyProvider().keyboard;
 
   const mouseProvider = config.providers.mouse
     ? registry.getMouse(config.providers.mouse)
-    : new KeysenderProvider().mouse;
+    : new AutoHotkeyProvider().mouse;
 
   const screenProvider = config.providers.screen
     ? registry.getScreen(config.providers.screen)
-    : new KeysenderProvider().screen;
+    : new AutoHotkeyProvider().screen;
 
   const clipboardProvider = config.providers.clipboard
     ? registry.getClipboard(config.providers.clipboard)
-    : new KeysenderProvider().clipboard;
+    : new AutoHotkeyProvider().clipboard;
 
   if (!keyboardProvider || !mouseProvider || !screenProvider || !clipboardProvider) {
     throw new Error('Failed to resolve all provider components');


### PR DESCRIPTION
## Summary
- Changed the default provider from keysender to AutoHotkey to reduce build tool requirements
- Updated documentation to use PowerShell syntax for environment variables (more appropriate for Windows users)
- Made keysender an optional dependency, allowing installation without complex native build tools

## Changes
1. **Configuration Updates**
   - Changed default provider from 'keysender' to 'autohotkey' in `src/config.ts`
   - Updated factory defaults to use AutoHotkeyProvider for all components

2. **Documentation Improvements**
   - Updated README environment variable examples from bash `export` to PowerShell `$env:` syntax
   - Reordered provider list to show AutoHotkey as default
   - Clarified that build tools are only needed for the optional keysender provider

3. **Dependency Management**
   - Moved keysender from dependencies to optionalDependencies in package.json
   - This allows users to install MCPControl without requiring native build tools

## Test plan
- [x] Code builds successfully with `npm run build`
- [x] Code passes linting with `npm run lint`
- [x] Code is properly formatted with `npm run format`
- [ ] Test that AutoHotkey provider works as default
- [ ] Test that keysender can still be installed as optional dependency
- [ ] Verify documentation is clear for Windows users

🤖 Generated with [Claude Code](https://claude.ai/code)