### PR TITLE
Remove RobotJS references

### DIFF
--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -33,9 +33,6 @@ export function initializeProviders(): void {
   registry.registerClipboard('autohotkey', autohotkeyProvider.clipboard);
 
   // TODO: Register other providers as they are implemented
-  // registry.registerKeyboard('robotjs', new RobotJSKeyboardProvider());
-  // registry.registerMouse('robotjs', new RobotJSMouseProvider());
-  // registry.registerScreen('robotjs', new RobotJSScreenProvider());
 }
 
 /**


### PR DESCRIPTION
## Summary
- Removed commented-out RobotJS provider references from factory.ts
- The library hasn't been updated in a very long time, so we're going another route

## Test plan
- Since only comments were removed, no functional testing required

🤖 Generated with [Claude Code](https://claude.ai/code)